### PR TITLE
Fix deprecated methods

### DIFF
--- a/lib/honeypot-captcha.rb
+++ b/lib/honeypot-captcha.rb
@@ -3,7 +3,7 @@ require 'honeypot-captcha/form_tag_helper'
 module HoneypotCaptcha
   module SpamProtection
     def honeypot_fields
-      { :a_comment_body => 'Do not fill in this field' }
+      { a_comment_body: 'Do not fill in this field' }
     end
 
     def honeypot_string
@@ -11,18 +11,52 @@ module HoneypotCaptcha
     end
 
     def protect_from_spam
-      head :ok if honeypot_fields.any? { |f,l| !params[f].blank? }
+      head :ok if honeypot_fields.any? { |f, l| !params[f].blank? }
     end
 
     def self.included(base) # :nodoc:
       base.send :helper_method, :honeypot_fields
       base.send :helper_method, :honeypot_string
 
-      if base.respond_to? :before_filter
-        base.send :prepend_before_filter, :protect_from_spam, :only => [:create, :update]
+      if base.respond_to? :before_action
+        base.send :prepend_before_action, :protect_from_spam, only: %i[create update]
       end
+    end
+  end
+
+  module Honeypot
+    def form_tag_html(options)
+      honeypot = options.delete(:honeypot) || options.delete('honeypot')
+      html = super(options)
+      if honeypot
+        captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
+        if block_given?
+          html.insert(html.index('</form>'), captcha)
+        else
+          html += captcha
+        end
+      end
+      html
+    end
+
+    private
+
+    def honey_pot_captcha
+      html_ids = []
+      honeypot_fields.collect do |f, l|
+        html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
+        content_tag :div, id: html_id do
+          content_tag(:style, type: 'text/css', media: 'screen', scoped: 'scoped') do
+            "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
+          end +
+            label_tag(f, l) +
+            send(%i[text_field_tag text_area_tag][rand(2)], f)
+        end
+      end.join
     end
   end
 end
 
-ActionController::Base.send(:include, HoneypotCaptcha::SpamProtection) if defined?(ActionController::Base)
+if defined?(ActionController::Base)
+  ActionController::Base.send(:include, HoneypotCaptcha::SpamProtection)
+end

--- a/lib/honeypot-captcha/form_tag_helper.rb
+++ b/lib/honeypot-captcha/form_tag_helper.rb
@@ -2,36 +2,7 @@
 module ActionView
   module Helpers
     module FormTagHelper
-      def form_tag_html_with_honeypot(options)
-        honeypot = options.delete(:honeypot) || options.delete('honeypot')
-        html = form_tag_html_without_honeypot(options)
-        if honeypot
-          captcha = "".respond_to?(:html_safe) ? honey_pot_captcha.html_safe : honey_pot_captcha
-          if block_given?
-            html.insert(html.index('</form>'), captcha)
-          else
-            html += captcha
-          end
-        end
-        html
-      end
-      alias_method_chain :form_tag_html, :honeypot
-
-    private
-
-      def honey_pot_captcha
-        html_ids = []
-        honeypot_fields.collect do |f, l|
-          html_ids << (html_id = "#{f}_#{honeypot_string}_#{Time.now.to_i}")
-          content_tag :div, :id => html_id do
-            content_tag(:style, :type => 'text/css', :media => 'screen', :scoped => "scoped") do
-              "#{html_ids.map { |i| "##{i}" }.join(', ')} { display:none; }"
-            end +
-            label_tag(f, l) +
-            send([:text_field_tag, :text_area_tag][rand(2)], f)
-          end
-        end.join
-      end
+      prepend ::HoneypotCaptcha::Honeypot
     end
   end
 end


### PR DESCRIPTION
Remove `alias_method_chain` and `prepend_before_filter`. Drop support for ruby <= 1.9